### PR TITLE
バグを見つけましたので、修正案を送ります。

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ optional arguments:
                 default: 100
   --short SHORT 出力画像の短辺の長さ。アスペクト比は維持したままリサイズする。
                 指定しなかった場合オリジナルサイズで出力される。
-  --lg LOG, --log LOG
+  -lg LOG, --log LOG
                 検出したノド元位置を記録するtsvファイルのパス。未指定の場合、出力しない。
                 1行目に列名 image_name<tab>trimming_x
                 2行目以降に入力画像のファイル名と検出したノド元位置を記録する。

--- a/inference_divided.py
+++ b/inference_divided.py
@@ -111,7 +111,7 @@ def divide_facing_page(input, input_path=None, output="NO_DUMP",
         preds = model.predict(inputs, batch_size=1, verbose=1)
         results = bbox_util.detection_out(preds)
         # results[i][b, p] ... i: image index; b: bbox index; p: [label, confidence, xmin, ymin, xmax, ymax]
-        cnt += batch_size
+        
         for i, cvimg in enumerate(images):
             if len(results[i]) == 0:
                 top_conf = 0.0
@@ -123,7 +123,7 @@ def divide_facing_page(input, input_path=None, output="NO_DUMP",
 
             div_x = 0
             basename, ext_ori = os.path.splitext(
-                os.path.basename(filenames[i]))
+                os.path.basename(filenames[i + cnt]))
             if ext == "SAME":
                 ext = ext_ori
 
@@ -192,6 +192,8 @@ def divide_facing_page(input, input_path=None, output="NO_DUMP",
                         im.save(os.path.join(output+'_rect', basename+ext),
                                 dpi=(dpiinfo["width_dpi"], dpiinfo["height_dpi"]),
                                 quality=quality)
+
+        cnt += batch_size
 
         del inputs, images
         gc.collect()


### PR DESCRIPTION
特に、 inference_divided.py のほうは、要修正かと思います。 `+ cnt`のような処理を加えないと、バッチサイズの中だけでbasenameを取りにいくため、分割後の画像がずれてしまうようでした。